### PR TITLE
Change interface for agi::error_detection::crc8 and fix linting errors

### DIFF
--- a/error_detection/error_detection.cc
+++ b/error_detection/error_detection.cc
@@ -5,17 +5,19 @@
 
 #include "error_detection.h"
 
-uint8_t agi::error_detection::crc8(const uint8_t* data, std::size_t length) {
+#include <climits>
+
+uint8_t agi::error_detection::crc8(std::span<uint8_t> data) {
     constexpr uint8_t CRC8_POLYNOMIAL = 0x07; // CRC-8 Generator polynomial
     constexpr uint8_t CRC8_MSB = (1U << 7U); // Most significat bit of byte
 
     uint8_t crc = 0x00;
 
-    for (std::size_t i = 0; i < length; i++) {
-        crc ^= data[i];
-        for (int b = 0; b < 8; b++) {
+    for (const uint8_t val : data) {
+        crc ^= val;
+        for (int b = 0; b < CHAR_BIT; b++) {
             if (crc & CRC8_MSB) {
-                crc = (crc << 1U) ^ CRC8_POLYNOMIAL;
+                crc = (crc << 1U) ^ CRC8_POLYNOMIAL; // NOLINT(*-signed-bitwise)
             } else {
                 crc <<= 1U;
             }

--- a/error_detection/error_detection.h
+++ b/error_detection/error_detection.h
@@ -5,17 +5,18 @@
 
 #pragma once
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
+#include <span>
 
 namespace agi::error_detection {
 
 /**
  * @brief Compute 8 bit checksum on data buffer using polynomial division based CRC-8 algorithm
  * 
- * @param data, length
+ * @param data
  * @return 8 bit CRC checksum
  */
-uint8_t crc8(const uint8_t* data, std::size_t length);
+uint8_t crc8(std::span<uint8_t> data);
 
 } // namespace agi::error_detection


### PR DESCRIPTION
Modified interface to use `std::span` (contains a pointer to a buffer and the buffer size) since it's safer than passing a raw pointer and allows us to use things like range-based for loops. Also fixed some things that will soon be lint errors.